### PR TITLE
Add customisability of severity level at which to fail GHA action

### DIFF
--- a/.github/workflows/fixtures/openapi.json
+++ b/.github/workflows/fixtures/openapi.json
@@ -189,7 +189,8 @@
                 "available",
                 "pending",
                 "sold"
-              ]
+              ],
+              "nullable": "true"
             }
           }
         ],

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,13 +22,13 @@ jobs:
 
       - id: test1
         name: "Test 1: Validate at Severity level 1 (Errors)"
-        uses: char0n/apidom-validate@main
+        uses: amandalian/apidom-validate@main
         with:
           definition-file: ./.github/workflows/fixtures/openapi.json
       - id: test2
         name: "Test 2: Validate at Severity level 4 (Hints)"
         if: success() || failure()
-        uses: char0n/apidom-validate@main
+        uses: amandalian/apidom-validate@main
         with:
           definition-file: ./.github/workflows/fixtures/openapi.json
           fails-on: 4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,13 +22,13 @@ jobs:
 
       - id: test1
         name: "Test 1: Validate at Severity level 1 (Errors)"
-        uses: amandalian/apidom-validate@main
+        uses: char0n/apidom-validate@main
         with:
           definition-file: ./.github/workflows/fixtures/openapi.json
       - id: test2
         name: "Test 2: Validate at Severity level 4 (Hints)"
         if: success() || failure()
-        uses: amandalian/apidom-validate@main
+        uses: char0n/apidom-validate@main
         with:
           definition-file: ./.github/workflows/fixtures/openapi.json
           fails-on: 4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,45 @@ on:
 jobs:
   test_github_action:
     runs-on: ubuntu-latest
+    continue-on-error: true
+    outputs:
+      output1: ${{ steps.test1.outcome }}
+      output2: ${{ steps.test2.outcome }}
 
     steps:
       - uses: actions/checkout@v2
-      - uses: char0n/apidom-validate@main
+
+      - id: test1
+        name: "Test 1: Validate at Severity level 1 (Errors)"
+        uses: amandalian/apidom-validate@main
         with:
           definition-file: ./.github/workflows/fixtures/openapi.json
+      - id: test2
+        name: "Test 2: Validate at Severity level 4 (Hints)"
+        if: success() || failure()
+        uses: amandalian/apidom-validate@main
+        with:
+          definition-file: ./.github/workflows/fixtures/openapi.json
+          fails-on: 4
 
+  verify_outcomes:
+    needs: test_github_action
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Compare Expected vs Actual Outcomes
+        run: |
+          echo ""
+          echo " Test | Definition File | Fails On Level | Expected Outcome | Actual Outcome"
+          echo "------|-----------------|----------------|------------------|----------------"
+          echo "   1  |  openapi.json   |       1        |     success      |    ${{ needs.test_github_action.outputs['output1'] }}"
+          echo "   2  |  openapi.json   |       4        |     failure      |    ${{ needs.test_github_action.outputs['output2'] }}"
+          echo ""
 
+          if [ "${{ needs.test_github_action.outputs['output1'] }}" == "success" ] && [ "${{ needs.test_github_action.outputs['output2'] }}" == "failure" ] ; then
+            echo "SUCCESS: Actual outcomes match expected outcomes."
+            exit 0
+          else
+            echo "FAILED: Actual outcomes do not match expected outcomes."
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ Validation rules are exactly the same as the one that https://editor-next.swagge
 
 **Required** Path to definition file.
 
+## `fails-on`
+
+Severity level at which to fail action. Default `1`, if not specified.
+- `1`: Fails if **error** messages exist in validation output
+- `2`: Fails if **error** or **warning** messages exist in validation output
+- `3`: Fails if **error**, **warning** or **information** messages exist in validation output
+- `4`: Fails if **error**, **warning**, **information** or **hint** messages exist in validation output
 
 ## Example usage
 
@@ -34,4 +41,5 @@ Validation rules are exactly the same as the one that https://editor-next.swagge
 uses: char0n/apidom-validate@v1
 with:
   definition-file: 'path/to/my/openapi.yaml'
+  fails-on: 2
 ```

--- a/action.yml
+++ b/action.yml
@@ -5,9 +5,15 @@ inputs:
     description: Path to definition file
     required: true
   fails-on:
+    type: choice
     description: Severity level at which to fail action
     required: false
-    default: '1'
+    options: 
+    - 1
+    - 2
+    - 3
+    - 4
+    default: 1
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -4,11 +4,16 @@ inputs:
   definition-file:
     description: Path to definition file
     required: true
+  fails-on:
+    description: Severity level at which to fail action
+    required: false
+    default: '1'
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
     - ${{ inputs.definition-file }}
+    - ${{ inputs.fails-on }}
 branding:
   icon: 'file-text'
   color: 'green'

--- a/validate.cjs
+++ b/validate.cjs
@@ -76,7 +76,7 @@ const mapDiagnostics = (diagnostics) => {
       condition = hints.length + information.length + warnings.length + errors.length > 0;
       break;
     default:
-      console.error(`Invalid failsOn value: ${failsOn}`);
+      core.error(`\u001b[1;31mInvalid failsOn value: ${failsOn}`);
       process.exit(1);
   }
 

--- a/validate.cjs
+++ b/validate.cjs
@@ -7,18 +7,26 @@ const core = require('@actions/core');
 const { TextDocument } = require('vscode-languageserver-textdocument');
 
 
-const [, , definitionFile, failsOn] = process.argv;
+const definitionFile = process.argv.at(2);
+let failsOn = parseInt(process.argv.at(3), 10);
 const definitionFilePath = path.join('/github/workspace', definitionFile);
 const definitionFileContent = fs.readFileSync(definitionFilePath, { encoding:'utf8', flag:'r' });
 const languageService = getLanguageService({});
 const textDocument = TextDocument.create(definitionFile, 'apidom', 0, definitionFileContent);
 
+const DiagnosticSeverity = {
+  Error: 1,
+  Warning: 2,
+  Information: 3,
+  Hint: 4,
+}
+
 const mapLine = (range) => `${range.start.line}:${range.start.character}`;
-const mapSeverity = (severity) => severity === 1
+const mapSeverity = (severity) => severity === DiagnosticSeverity.Error
   ? 'error'
-  : severity === 2
+  : severity === DiagnosticSeverity.Warning
   ? 'warning'
-  : severity === 3
+  : severity === DiagnosticSeverity.Information
   ? 'information'
   : 'hint';
 const mapDiagnostic = ({ range, severity, code, message }) => ({
@@ -34,15 +42,19 @@ const mapDiagnostics = (diagnostics) => {
   logger.table(diagnostics.map(mapDiagnostic));
   return (ts.read() || '').toString();
 };
+const getSeverityCount = (severity, { errors, warnings, information, hints }) => {
+  const components = [errors, warnings, information, hints];
+  return components.slice(0, severity).reduce((total, current) => total + current.length, 0);
+};
 
 (async () => {
   core.info(`\u001b[1mApiDOM lint ${definitionFile}`);
 
   const validationResult = await languageService.doValidation(textDocument);
-  const errors = validationResult.filter((diagnostic) => diagnostic.severity === 1);
-  const warnings = validationResult.filter((diagnostic) => diagnostic.severity === 2);
-  const information = validationResult.filter((diagnostic) => diagnostic.severity === 3);
-  const hints = validationResult.filter((diagnostic) => diagnostic.severity === 4);
+  const errors = validationResult.filter((diagnostic) => diagnostic.severity === DiagnosticSeverity.Error);
+  const warnings = validationResult.filter((diagnostic) => diagnostic.severity === DiagnosticSeverity.Warning);
+  const information = validationResult.filter((diagnostic) => diagnostic.severity === DiagnosticSeverity.Information);
+  const hints = validationResult.filter((diagnostic) => diagnostic.severity === DiagnosticSeverity.Hint);
 
   languageService.terminate();
 
@@ -61,27 +73,14 @@ const mapDiagnostics = (diagnostics) => {
     : '\u001b[1;1m';
   core.info(`${color}${errors.length + warnings.length} problems (${errors.length} error, ${warnings.length} warnings, ${information.length} information, ${hints.length} hints)`);
 
-  let condition;
-  switch (failsOn) {
-    case '1':
-      condition = errors.length > 0;
-      break;
-    case '2':
-      condition = warnings.length + errors.length > 0;
-      break;
-    case '3':
-      condition = information.length + warnings.length + errors.length > 0;
-      break;
-    case '4':
-      condition = hints.length + information.length + warnings.length + errors.length > 0;
-      break;
-    default:
-      core.error(`\u001b[1;31mInvalid failsOn value: ${failsOn}`);
-      process.exit(1);
+  // handle unknown severity level
+  if (!Object.values(DiagnosticSeverity).includes(failsOn)) {
+    core.warning(`\u001b[1;33mUnknown severity level ${failsOn}, defaulting to ${DiagnosticSeverity.Error}`);
+    failsOn = DiagnosticSeverity.Error;
   }
 
-  // fail the action on condition
-  if (condition) {
+  // fail the action depending on severity defined in `failsOn`
+  if (getSeverityCount(failsOn, { errors, warnings, information, hints }) > 0) {
     core.setFailed('');
   }
 })();

--- a/validate.cjs
+++ b/validate.cjs
@@ -7,7 +7,7 @@ const core = require('@actions/core');
 const { TextDocument } = require('vscode-languageserver-textdocument');
 
 
-const [, , definitionFile] = process.argv;
+const [, , definitionFile, failsOn] = process.argv;
 const definitionFilePath = path.join('/github/workspace', definitionFile);
 const definitionFileContent = fs.readFileSync(definitionFilePath, { encoding:'utf8', flag:'r' });
 const languageService = getLanguageService({});
@@ -61,8 +61,27 @@ const mapDiagnostics = (diagnostics) => {
     : '\u001b[1;1m';
   core.info(`${color}${errors.length + warnings.length} problems (${errors.length} error, ${warnings.length} warnings, ${information.length} information, ${hints.length} hints)`);
 
-  // fail the action on errors
-  if (errors.length > 0) {
+  let condition;
+  switch (failsOn) {
+    case '1':
+      condition = errors.length > 0;
+      break;
+    case '2':
+      condition = warnings.length + errors.length > 0;
+      break;
+    case '3':
+      condition = information.length + warnings.length + errors.length > 0;
+      break;
+    case '4':
+      condition = hints.length + information.length + warnings.length + errors.length > 0;
+      break;
+    default:
+      console.error(`Invalid failsOn value: ${failsOn}`);
+      process.exit(1);
+  }
+
+  // fail the action on condition
+  if (condition) {
     core.setFailed('');
   }
 })();

--- a/validate.cjs
+++ b/validate.cjs
@@ -8,7 +8,7 @@ const { TextDocument } = require('vscode-languageserver-textdocument');
 
 
 const definitionFile = process.argv.at(2);
-let failsOn = parseInt(process.argv.at(3), 10);
+const failsOn = parseInt(process.argv.at(3), 10);
 const definitionFilePath = path.join('/github/workspace', definitionFile);
 const definitionFileContent = fs.readFileSync(definitionFilePath, { encoding:'utf8', flag:'r' });
 const languageService = getLanguageService({});
@@ -72,12 +72,6 @@ const getSeverityCount = (severity, { errors, warnings, information, hints }) =>
     ? '\u001b[1;33m'
     : '\u001b[1;1m';
   core.info(`${color}${errors.length + warnings.length} problems (${errors.length} error, ${warnings.length} warnings, ${information.length} information, ${hints.length} hints)`);
-
-  // handle unknown severity level
-  if (!Object.values(DiagnosticSeverity).includes(failsOn)) {
-    core.warning(`\u001b[1;33mUnknown severity level ${failsOn}, defaulting to ${DiagnosticSeverity.Error}`);
-    failsOn = DiagnosticSeverity.Error;
-  }
 
   // fail the action depending on severity defined in `failsOn`
   if (getSeverityCount(failsOn, { errors, warnings, information, hints }) > 0) {


### PR DESCRIPTION
Optional additional input of `fails-on` when using `apidom-validate` action. Stricter enforcement of OpenAI specification e.g., use case of hints alone failing the validation.

I didn't change the GHA action name in the test workflow file yet so we can [see how it works](https://github.com/amandalian/apidom-validate/actions/runs/6970679069).

My first time contributing to open source so open to any feedback!